### PR TITLE
fix: defensive coding to check ProgressBar==nil to avoid panic

### DIFF
--- a/bar/bar.go
+++ b/bar/bar.go
@@ -104,6 +104,9 @@ func (p *ProgressBar) Write(bs []byte) (n int, err error) {
 
 // draw simple sentences, suitable for non-tty interface
 func (p *ProgressBar) drawSimple() {
+	if p == nil {
+		return
+	}
 	p.onceStart.Do(func() {
 		fmt.Printf("%s In progress\n", p.Prepend)
 	})

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "v1.0.32-io05"
+var version = "v1.0.33"
 
 func init() {
 	rootCmd.AddCommand(versionCmd)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents crashes when drawing progress bars and bumps the CLI version.
> 
> - Add a nil guard in `bar.ProgressBar.drawSimple` to avoid panics when `ProgressBar` may be `nil`
> - Update `cmd/version.go` version string to `v1.0.33`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d525acabdd6cf768fe30653038251c6ff07c3043. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->